### PR TITLE
Fix action run triggered by an action

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Setup Java 17
       - uses: actions/setup-java@v4


### PR DESCRIPTION
Actions don't trigger after an action pushes to a branch, removing the persisting credentials causes the action to run with GITHUB_TOKEN rather than the users token.